### PR TITLE
Fixed chunk align issue.

### DIFF
--- a/dpkt/sctp.py
+++ b/dpkt/sctp.py
@@ -51,7 +51,7 @@ class SCTP(dpkt.Packet):
         while self.data:
             chunk = Chunk(self.data)
             l.append(chunk)
-            self.data = self.data[len(chunk):]
+            self.data = self.data[int((len(chunk)+4)/4)*4:]
         self.data = self.chunks = l
 
     def __len__(self):


### PR DESCRIPTION
SCTP chunk is aligned with quad-byte.  
Change self.data = self.data[len(chunk):] to self.data = self.data[int((len(chunk)+4)/4)*4:]